### PR TITLE
Fix initialization issues for pseudorandom number streams

### DIFF
--- a/src/random_lcg.F90
+++ b/src/random_lcg.F90
@@ -18,7 +18,7 @@ module random_lcg
   real(8)    :: prn_norm   ! 2^(-M)
   integer    :: stream     ! current RNG stream
 
-!$omp threadprivate(prn_seed)
+!$omp threadprivate(prn_seed, stream)
 
   public :: prn
   public :: initialize_prng
@@ -60,11 +60,13 @@ contains
 
     integer :: i
 
-    stream     = STREAM_TRACKING
     prn_seed0  = seed
+!$omp parallel
     do i = 1, N_STREAMS
       prn_seed(i) = prn_seed0 + i - 1
     end do
+    stream     = STREAM_TRACKING
+!$omp end parallel
     prn_mult   = 2806196910506780709_8
     prn_add    = 1_8
     prn_bits   = 63


### PR DESCRIPTION
The `stream` variable is now threadprivate and both `stream` and `prn_seed` are initialized inside an OpenMP parallel region so that all threads have appropriate values.
