### PR TITLE
Partial S(a,b) tests

### DIFF
--- a/openmc/material.py
+++ b/openmc/material.py
@@ -982,7 +982,7 @@ class Material(IDManagerMixin):
             for sab in self._sab:
                 subelement = ET.SubElement(element, "sab")
                 subelement.set("name", sab[0])
-                subelement.set("fraction", sab[1])
+                subelement.set("fraction", str(sab[1]))
 
         return element
 

--- a/tests/test_asymmetric_lattice/inputs_true.dat
+++ b/tests/test_asymmetric_lattice/inputs_true.dat
@@ -78,7 +78,7 @@
     <nuclide ao="1.0" name="O16" />
     <nuclide ao="0.000649" name="B10" />
     <nuclide ao="0.002689" name="B11" />
-    <sab name="c_H_in_H2O" />
+    <sab fraction="1.0" name="c_H_in_H2O" />
   </material>
   <material id="4" name="Hot borated water">
     <density units="atom/b-cm" value="0.06614" />
@@ -86,7 +86,7 @@
     <nuclide ao="1.0" name="O16" />
     <nuclide ao="0.000649" name="B10" />
     <nuclide ao="0.002689" name="B11" />
-    <sab name="c_H_in_H2O" />
+    <sab fraction="1.0" name="c_H_in_H2O" />
   </material>
   <material id="5" name="Reactor pressure vessel steel">
     <density units="g/cm3" value="7.9" />
@@ -114,7 +114,7 @@
     <nuclide name="Ni58" wo="0.055298376566" />
     <nuclide name="Mn55" wo="0.018287" />
     <nuclide name="Cr52" wo="0.145407678031" />
-    <sab name="c_H_in_H2O" />
+    <sab fraction="1.0" name="c_H_in_H2O" />
   </material>
   <material id="7" name="Upper radial reflector / Top plate region">
     <density units="g/cm3" value="4.28" />
@@ -129,7 +129,7 @@
     <nuclide name="Ni58" wo="0.055815129186" />
     <nuclide name="Mn55" wo="0.0184579" />
     <nuclide name="Cr52" wo="0.146766614995" />
-    <sab name="c_H_in_H2O" />
+    <sab fraction="1.0" name="c_H_in_H2O" />
   </material>
   <material id="8" name="Bottom plate region">
     <density units="g/cm3" value="7.184" />
@@ -144,7 +144,7 @@
     <nuclide name="Ni58" wo="0.059855207342" />
     <nuclide name="Mn55" wo="0.019794" />
     <nuclide name="Cr52" wo="0.157390026871" />
-    <sab name="c_H_in_H2O" />
+    <sab fraction="1.0" name="c_H_in_H2O" />
   </material>
   <material id="9" name="Bottom nozzle region">
     <density units="g/cm3" value="2.53" />
@@ -159,7 +159,7 @@
     <nuclide name="Ni58" wo="0.047211231662" />
     <nuclide name="Mn55" wo="0.0156126" />
     <nuclide name="Cr52" wo="0.124142524198" />
-    <sab name="c_H_in_H2O" />
+    <sab fraction="1.0" name="c_H_in_H2O" />
   </material>
   <material id="10" name="Top nozzle region">
     <density units="g/cm3" value="1.746" />
@@ -174,7 +174,7 @@
     <nuclide name="Ni58" wo="0.04104621835" />
     <nuclide name="Mn55" wo="0.0135739" />
     <nuclide name="Cr52" wo="0.107931450781" />
-    <sab name="c_H_in_H2O" />
+    <sab fraction="1.0" name="c_H_in_H2O" />
   </material>
   <material id="11" name="Top of fuel assemblies">
     <density units="g/cm3" value="3.044" />
@@ -187,7 +187,7 @@
     <nuclide name="Zr92" wo="0.14759527104" />
     <nuclide name="Zr94" wo="0.15280552077" />
     <nuclide name="Zr96" wo="0.02511169542" />
-    <sab name="c_H_in_H2O" />
+    <sab fraction="1.0" name="c_H_in_H2O" />
   </material>
   <material id="12" name="Bottom of fuel assemblies">
     <density units="g/cm3" value="1.762" />
@@ -200,7 +200,7 @@
     <nuclide name="Zr92" wo="0.1274914944" />
     <nuclide name="Zr94" wo="0.1319920622" />
     <nuclide name="Zr96" wo="0.0216912612" />
-    <sab name="c_H_in_H2O" />
+    <sab fraction="1.0" name="c_H_in_H2O" />
   </material>
 </materials>
 <?xml version='1.0' encoding='utf-8'?>

--- a/tests/test_diff_tally/inputs_true.dat
+++ b/tests/test_diff_tally/inputs_true.dat
@@ -170,7 +170,7 @@
     <nuclide ao="1.0" name="O16" />
     <nuclide ao="0.000649" name="B10" />
     <nuclide ao="0.002689" name="B11" />
-    <sab name="c_H_in_H2O" />
+    <sab fraction="1.0" name="c_H_in_H2O" />
   </material>
   <material id="4" name="Hot borated water">
     <density units="atom/b-cm" value="0.06614" />
@@ -178,7 +178,7 @@
     <nuclide ao="1.0" name="O16" />
     <nuclide ao="0.000649" name="B10" />
     <nuclide ao="0.002689" name="B11" />
-    <sab name="c_H_in_H2O" />
+    <sab fraction="1.0" name="c_H_in_H2O" />
   </material>
   <material id="5" name="Reactor pressure vessel steel">
     <density units="g/cm3" value="7.9" />
@@ -206,7 +206,7 @@
     <nuclide name="Ni58" wo="0.055298376566" />
     <nuclide name="Mn55" wo="0.018287" />
     <nuclide name="Cr52" wo="0.145407678031" />
-    <sab name="c_H_in_H2O" />
+    <sab fraction="1.0" name="c_H_in_H2O" />
   </material>
   <material id="7" name="Upper radial reflector / Top plate region">
     <density units="g/cm3" value="4.28" />
@@ -221,7 +221,7 @@
     <nuclide name="Ni58" wo="0.055815129186" />
     <nuclide name="Mn55" wo="0.0184579" />
     <nuclide name="Cr52" wo="0.146766614995" />
-    <sab name="c_H_in_H2O" />
+    <sab fraction="1.0" name="c_H_in_H2O" />
   </material>
   <material id="8" name="Bottom plate region">
     <density units="g/cm3" value="7.184" />
@@ -236,7 +236,7 @@
     <nuclide name="Ni58" wo="0.059855207342" />
     <nuclide name="Mn55" wo="0.019794" />
     <nuclide name="Cr52" wo="0.157390026871" />
-    <sab name="c_H_in_H2O" />
+    <sab fraction="1.0" name="c_H_in_H2O" />
   </material>
   <material id="9" name="Bottom nozzle region">
     <density units="g/cm3" value="2.53" />
@@ -251,7 +251,7 @@
     <nuclide name="Ni58" wo="0.047211231662" />
     <nuclide name="Mn55" wo="0.0156126" />
     <nuclide name="Cr52" wo="0.124142524198" />
-    <sab name="c_H_in_H2O" />
+    <sab fraction="1.0" name="c_H_in_H2O" />
   </material>
   <material id="10" name="Top nozzle region">
     <density units="g/cm3" value="1.746" />
@@ -266,7 +266,7 @@
     <nuclide name="Ni58" wo="0.04104621835" />
     <nuclide name="Mn55" wo="0.0135739" />
     <nuclide name="Cr52" wo="0.107931450781" />
-    <sab name="c_H_in_H2O" />
+    <sab fraction="1.0" name="c_H_in_H2O" />
   </material>
   <material id="11" name="Top of fuel assemblies">
     <density units="g/cm3" value="3.044" />
@@ -279,7 +279,7 @@
     <nuclide name="Zr92" wo="0.14759527104" />
     <nuclide name="Zr94" wo="0.15280552077" />
     <nuclide name="Zr96" wo="0.02511169542" />
-    <sab name="c_H_in_H2O" />
+    <sab fraction="1.0" name="c_H_in_H2O" />
   </material>
   <material id="12" name="Bottom of fuel assemblies">
     <density units="g/cm3" value="1.762" />
@@ -292,7 +292,7 @@
     <nuclide name="Zr92" wo="0.1274914944" />
     <nuclide name="Zr94" wo="0.1319920622" />
     <nuclide name="Zr96" wo="0.0216912612" />
-    <sab name="c_H_in_H2O" />
+    <sab fraction="1.0" name="c_H_in_H2O" />
   </material>
 </materials>
 <?xml version='1.0' encoding='utf-8'?>

--- a/tests/test_filter_energyfun/inputs_true.dat
+++ b/tests/test_filter_energyfun/inputs_true.dat
@@ -171,7 +171,7 @@
     <nuclide ao="1.0" name="O16" />
     <nuclide ao="0.000649" name="B10" />
     <nuclide ao="0.002689" name="B11" />
-    <sab name="c_H_in_H2O" />
+    <sab fraction="1.0" name="c_H_in_H2O" />
   </material>
   <material id="4" name="Hot borated water">
     <density units="atom/b-cm" value="0.06614" />
@@ -179,7 +179,7 @@
     <nuclide ao="1.0" name="O16" />
     <nuclide ao="0.000649" name="B10" />
     <nuclide ao="0.002689" name="B11" />
-    <sab name="c_H_in_H2O" />
+    <sab fraction="1.0" name="c_H_in_H2O" />
   </material>
   <material id="5" name="Reactor pressure vessel steel">
     <density units="g/cm3" value="7.9" />
@@ -207,7 +207,7 @@
     <nuclide name="Ni58" wo="0.055298376566" />
     <nuclide name="Mn55" wo="0.018287" />
     <nuclide name="Cr52" wo="0.145407678031" />
-    <sab name="c_H_in_H2O" />
+    <sab fraction="1.0" name="c_H_in_H2O" />
   </material>
   <material id="7" name="Upper radial reflector / Top plate region">
     <density units="g/cm3" value="4.28" />
@@ -222,7 +222,7 @@
     <nuclide name="Ni58" wo="0.055815129186" />
     <nuclide name="Mn55" wo="0.0184579" />
     <nuclide name="Cr52" wo="0.146766614995" />
-    <sab name="c_H_in_H2O" />
+    <sab fraction="1.0" name="c_H_in_H2O" />
   </material>
   <material id="8" name="Bottom plate region">
     <density units="g/cm3" value="7.184" />
@@ -237,7 +237,7 @@
     <nuclide name="Ni58" wo="0.059855207342" />
     <nuclide name="Mn55" wo="0.019794" />
     <nuclide name="Cr52" wo="0.157390026871" />
-    <sab name="c_H_in_H2O" />
+    <sab fraction="1.0" name="c_H_in_H2O" />
   </material>
   <material id="9" name="Bottom nozzle region">
     <density units="g/cm3" value="2.53" />
@@ -252,7 +252,7 @@
     <nuclide name="Ni58" wo="0.047211231662" />
     <nuclide name="Mn55" wo="0.0156126" />
     <nuclide name="Cr52" wo="0.124142524198" />
-    <sab name="c_H_in_H2O" />
+    <sab fraction="1.0" name="c_H_in_H2O" />
   </material>
   <material id="10" name="Top nozzle region">
     <density units="g/cm3" value="1.746" />
@@ -267,7 +267,7 @@
     <nuclide name="Ni58" wo="0.04104621835" />
     <nuclide name="Mn55" wo="0.0135739" />
     <nuclide name="Cr52" wo="0.107931450781" />
-    <sab name="c_H_in_H2O" />
+    <sab fraction="1.0" name="c_H_in_H2O" />
   </material>
   <material id="11" name="Top of fuel assemblies">
     <density units="g/cm3" value="3.044" />
@@ -280,7 +280,7 @@
     <nuclide name="Zr92" wo="0.14759527104" />
     <nuclide name="Zr94" wo="0.15280552077" />
     <nuclide name="Zr96" wo="0.02511169542" />
-    <sab name="c_H_in_H2O" />
+    <sab fraction="1.0" name="c_H_in_H2O" />
   </material>
   <material id="12" name="Bottom of fuel assemblies">
     <density units="g/cm3" value="1.762" />
@@ -293,7 +293,7 @@
     <nuclide name="Zr92" wo="0.1274914944" />
     <nuclide name="Zr94" wo="0.1319920622" />
     <nuclide name="Zr96" wo="0.0216912612" />
-    <sab name="c_H_in_H2O" />
+    <sab fraction="1.0" name="c_H_in_H2O" />
   </material>
 </materials>
 <?xml version='1.0' encoding='utf-8'?>

--- a/tests/test_filter_mesh/inputs_true.dat
+++ b/tests/test_filter_mesh/inputs_true.dat
@@ -170,7 +170,7 @@
     <nuclide ao="1.0" name="O16" />
     <nuclide ao="0.000649" name="B10" />
     <nuclide ao="0.002689" name="B11" />
-    <sab name="c_H_in_H2O" />
+    <sab fraction="1.0" name="c_H_in_H2O" />
   </material>
   <material id="4" name="Hot borated water">
     <density units="atom/b-cm" value="0.06614" />
@@ -178,7 +178,7 @@
     <nuclide ao="1.0" name="O16" />
     <nuclide ao="0.000649" name="B10" />
     <nuclide ao="0.002689" name="B11" />
-    <sab name="c_H_in_H2O" />
+    <sab fraction="1.0" name="c_H_in_H2O" />
   </material>
   <material id="5" name="Reactor pressure vessel steel">
     <density units="g/cm3" value="7.9" />
@@ -206,7 +206,7 @@
     <nuclide name="Ni58" wo="0.055298376566" />
     <nuclide name="Mn55" wo="0.018287" />
     <nuclide name="Cr52" wo="0.145407678031" />
-    <sab name="c_H_in_H2O" />
+    <sab fraction="1.0" name="c_H_in_H2O" />
   </material>
   <material id="7" name="Upper radial reflector / Top plate region">
     <density units="g/cm3" value="4.28" />
@@ -221,7 +221,7 @@
     <nuclide name="Ni58" wo="0.055815129186" />
     <nuclide name="Mn55" wo="0.0184579" />
     <nuclide name="Cr52" wo="0.146766614995" />
-    <sab name="c_H_in_H2O" />
+    <sab fraction="1.0" name="c_H_in_H2O" />
   </material>
   <material id="8" name="Bottom plate region">
     <density units="g/cm3" value="7.184" />
@@ -236,7 +236,7 @@
     <nuclide name="Ni58" wo="0.059855207342" />
     <nuclide name="Mn55" wo="0.019794" />
     <nuclide name="Cr52" wo="0.157390026871" />
-    <sab name="c_H_in_H2O" />
+    <sab fraction="1.0" name="c_H_in_H2O" />
   </material>
   <material id="9" name="Bottom nozzle region">
     <density units="g/cm3" value="2.53" />
@@ -251,7 +251,7 @@
     <nuclide name="Ni58" wo="0.047211231662" />
     <nuclide name="Mn55" wo="0.0156126" />
     <nuclide name="Cr52" wo="0.124142524198" />
-    <sab name="c_H_in_H2O" />
+    <sab fraction="1.0" name="c_H_in_H2O" />
   </material>
   <material id="10" name="Top nozzle region">
     <density units="g/cm3" value="1.746" />
@@ -266,7 +266,7 @@
     <nuclide name="Ni58" wo="0.04104621835" />
     <nuclide name="Mn55" wo="0.0135739" />
     <nuclide name="Cr52" wo="0.107931450781" />
-    <sab name="c_H_in_H2O" />
+    <sab fraction="1.0" name="c_H_in_H2O" />
   </material>
   <material id="11" name="Top of fuel assemblies">
     <density units="g/cm3" value="3.044" />
@@ -279,7 +279,7 @@
     <nuclide name="Zr92" wo="0.14759527104" />
     <nuclide name="Zr94" wo="0.15280552077" />
     <nuclide name="Zr96" wo="0.02511169542" />
-    <sab name="c_H_in_H2O" />
+    <sab fraction="1.0" name="c_H_in_H2O" />
   </material>
   <material id="12" name="Bottom of fuel assemblies">
     <density units="g/cm3" value="1.762" />
@@ -292,7 +292,7 @@
     <nuclide name="Zr92" wo="0.1274914944" />
     <nuclide name="Zr94" wo="0.1319920622" />
     <nuclide name="Zr96" wo="0.0216912612" />
-    <sab name="c_H_in_H2O" />
+    <sab fraction="1.0" name="c_H_in_H2O" />
   </material>
 </materials>
 <?xml version='1.0' encoding='utf-8'?>

--- a/tests/test_iso_in_lab/inputs_true.dat
+++ b/tests/test_iso_in_lab/inputs_true.dat
@@ -170,7 +170,7 @@
     <nuclide ao="1.0" name="O16" scattering="iso-in-lab" />
     <nuclide ao="0.000649" name="B10" scattering="iso-in-lab" />
     <nuclide ao="0.002689" name="B11" scattering="iso-in-lab" />
-    <sab name="c_H_in_H2O" />
+    <sab fraction="1.0" name="c_H_in_H2O" />
   </material>
   <material id="4" name="Hot borated water">
     <density units="atom/b-cm" value="0.06614" />
@@ -178,7 +178,7 @@
     <nuclide ao="1.0" name="O16" scattering="iso-in-lab" />
     <nuclide ao="0.000649" name="B10" scattering="iso-in-lab" />
     <nuclide ao="0.002689" name="B11" scattering="iso-in-lab" />
-    <sab name="c_H_in_H2O" />
+    <sab fraction="1.0" name="c_H_in_H2O" />
   </material>
   <material id="5" name="Reactor pressure vessel steel">
     <density units="g/cm3" value="7.9" />
@@ -206,7 +206,7 @@
     <nuclide name="Ni58" scattering="iso-in-lab" wo="0.055298376566" />
     <nuclide name="Mn55" scattering="iso-in-lab" wo="0.018287" />
     <nuclide name="Cr52" scattering="iso-in-lab" wo="0.145407678031" />
-    <sab name="c_H_in_H2O" />
+    <sab fraction="1.0" name="c_H_in_H2O" />
   </material>
   <material id="7" name="Upper radial reflector / Top plate region">
     <density units="g/cm3" value="4.28" />
@@ -221,7 +221,7 @@
     <nuclide name="Ni58" scattering="iso-in-lab" wo="0.055815129186" />
     <nuclide name="Mn55" scattering="iso-in-lab" wo="0.0184579" />
     <nuclide name="Cr52" scattering="iso-in-lab" wo="0.146766614995" />
-    <sab name="c_H_in_H2O" />
+    <sab fraction="1.0" name="c_H_in_H2O" />
   </material>
   <material id="8" name="Bottom plate region">
     <density units="g/cm3" value="7.184" />
@@ -236,7 +236,7 @@
     <nuclide name="Ni58" scattering="iso-in-lab" wo="0.059855207342" />
     <nuclide name="Mn55" scattering="iso-in-lab" wo="0.019794" />
     <nuclide name="Cr52" scattering="iso-in-lab" wo="0.157390026871" />
-    <sab name="c_H_in_H2O" />
+    <sab fraction="1.0" name="c_H_in_H2O" />
   </material>
   <material id="9" name="Bottom nozzle region">
     <density units="g/cm3" value="2.53" />
@@ -251,7 +251,7 @@
     <nuclide name="Ni58" scattering="iso-in-lab" wo="0.047211231662" />
     <nuclide name="Mn55" scattering="iso-in-lab" wo="0.0156126" />
     <nuclide name="Cr52" scattering="iso-in-lab" wo="0.124142524198" />
-    <sab name="c_H_in_H2O" />
+    <sab fraction="1.0" name="c_H_in_H2O" />
   </material>
   <material id="10" name="Top nozzle region">
     <density units="g/cm3" value="1.746" />
@@ -266,7 +266,7 @@
     <nuclide name="Ni58" scattering="iso-in-lab" wo="0.04104621835" />
     <nuclide name="Mn55" scattering="iso-in-lab" wo="0.0135739" />
     <nuclide name="Cr52" scattering="iso-in-lab" wo="0.107931450781" />
-    <sab name="c_H_in_H2O" />
+    <sab fraction="1.0" name="c_H_in_H2O" />
   </material>
   <material id="11" name="Top of fuel assemblies">
     <density units="g/cm3" value="3.044" />
@@ -279,7 +279,7 @@
     <nuclide name="Zr92" scattering="iso-in-lab" wo="0.14759527104" />
     <nuclide name="Zr94" scattering="iso-in-lab" wo="0.15280552077" />
     <nuclide name="Zr96" scattering="iso-in-lab" wo="0.02511169542" />
-    <sab name="c_H_in_H2O" />
+    <sab fraction="1.0" name="c_H_in_H2O" />
   </material>
   <material id="12" name="Bottom of fuel assemblies">
     <density units="g/cm3" value="1.762" />
@@ -292,7 +292,7 @@
     <nuclide name="Zr92" scattering="iso-in-lab" wo="0.1274914944" />
     <nuclide name="Zr94" scattering="iso-in-lab" wo="0.1319920622" />
     <nuclide name="Zr96" scattering="iso-in-lab" wo="0.0216912612" />
-    <sab name="c_H_in_H2O" />
+    <sab fraction="1.0" name="c_H_in_H2O" />
   </material>
 </materials>
 <?xml version='1.0' encoding='utf-8'?>

--- a/tests/test_mgxs_library_ce_to_mg/inputs_true.dat
+++ b/tests/test_mgxs_library_ce_to_mg/inputs_true.dat
@@ -33,7 +33,7 @@
     <nuclide ao="0.024672" name="O16" />
     <nuclide ao="8.0042e-06" name="B10" />
     <nuclide ao="3.2218e-05" name="B11" />
-    <sab name="c_H_in_H2O" />
+    <sab fraction="1.0" name="c_H_in_H2O" />
   </material>
 </materials>
 <?xml version='1.0' encoding='utf-8'?>

--- a/tests/test_mgxs_library_condense/inputs_true.dat
+++ b/tests/test_mgxs_library_condense/inputs_true.dat
@@ -33,7 +33,7 @@
     <nuclide ao="0.024672" name="O16" />
     <nuclide ao="8.0042e-06" name="B10" />
     <nuclide ao="3.2218e-05" name="B11" />
-    <sab name="c_H_in_H2O" />
+    <sab fraction="1.0" name="c_H_in_H2O" />
   </material>
 </materials>
 <?xml version='1.0' encoding='utf-8'?>

--- a/tests/test_mgxs_library_distribcell/inputs_true.dat
+++ b/tests/test_mgxs_library_distribcell/inputs_true.dat
@@ -60,7 +60,7 @@
     <nuclide ao="0.024672" name="O16" />
     <nuclide ao="8.0042e-06" name="B10" />
     <nuclide ao="3.2218e-05" name="B11" />
-    <sab name="c_H_in_H2O" />
+    <sab fraction="1.0" name="c_H_in_H2O" />
   </material>
 </materials>
 <?xml version='1.0' encoding='utf-8'?>

--- a/tests/test_mgxs_library_hdf5/inputs_true.dat
+++ b/tests/test_mgxs_library_hdf5/inputs_true.dat
@@ -33,7 +33,7 @@
     <nuclide ao="0.024672" name="O16" />
     <nuclide ao="8.0042e-06" name="B10" />
     <nuclide ao="3.2218e-05" name="B11" />
-    <sab name="c_H_in_H2O" />
+    <sab fraction="1.0" name="c_H_in_H2O" />
   </material>
 </materials>
 <?xml version='1.0' encoding='utf-8'?>

--- a/tests/test_mgxs_library_mesh/inputs_true.dat
+++ b/tests/test_mgxs_library_mesh/inputs_true.dat
@@ -170,7 +170,7 @@
     <nuclide ao="1.0" name="O16" />
     <nuclide ao="0.000649" name="B10" />
     <nuclide ao="0.002689" name="B11" />
-    <sab name="c_H_in_H2O" />
+    <sab fraction="1.0" name="c_H_in_H2O" />
   </material>
   <material id="4" name="Hot borated water">
     <density units="atom/b-cm" value="0.06614" />
@@ -178,7 +178,7 @@
     <nuclide ao="1.0" name="O16" />
     <nuclide ao="0.000649" name="B10" />
     <nuclide ao="0.002689" name="B11" />
-    <sab name="c_H_in_H2O" />
+    <sab fraction="1.0" name="c_H_in_H2O" />
   </material>
   <material id="5" name="Reactor pressure vessel steel">
     <density units="g/cm3" value="7.9" />
@@ -206,7 +206,7 @@
     <nuclide name="Ni58" wo="0.055298376566" />
     <nuclide name="Mn55" wo="0.018287" />
     <nuclide name="Cr52" wo="0.145407678031" />
-    <sab name="c_H_in_H2O" />
+    <sab fraction="1.0" name="c_H_in_H2O" />
   </material>
   <material id="7" name="Upper radial reflector / Top plate region">
     <density units="g/cm3" value="4.28" />
@@ -221,7 +221,7 @@
     <nuclide name="Ni58" wo="0.055815129186" />
     <nuclide name="Mn55" wo="0.0184579" />
     <nuclide name="Cr52" wo="0.146766614995" />
-    <sab name="c_H_in_H2O" />
+    <sab fraction="1.0" name="c_H_in_H2O" />
   </material>
   <material id="8" name="Bottom plate region">
     <density units="g/cm3" value="7.184" />
@@ -236,7 +236,7 @@
     <nuclide name="Ni58" wo="0.059855207342" />
     <nuclide name="Mn55" wo="0.019794" />
     <nuclide name="Cr52" wo="0.157390026871" />
-    <sab name="c_H_in_H2O" />
+    <sab fraction="1.0" name="c_H_in_H2O" />
   </material>
   <material id="9" name="Bottom nozzle region">
     <density units="g/cm3" value="2.53" />
@@ -251,7 +251,7 @@
     <nuclide name="Ni58" wo="0.047211231662" />
     <nuclide name="Mn55" wo="0.0156126" />
     <nuclide name="Cr52" wo="0.124142524198" />
-    <sab name="c_H_in_H2O" />
+    <sab fraction="1.0" name="c_H_in_H2O" />
   </material>
   <material id="10" name="Top nozzle region">
     <density units="g/cm3" value="1.746" />
@@ -266,7 +266,7 @@
     <nuclide name="Ni58" wo="0.04104621835" />
     <nuclide name="Mn55" wo="0.0135739" />
     <nuclide name="Cr52" wo="0.107931450781" />
-    <sab name="c_H_in_H2O" />
+    <sab fraction="1.0" name="c_H_in_H2O" />
   </material>
   <material id="11" name="Top of fuel assemblies">
     <density units="g/cm3" value="3.044" />
@@ -279,7 +279,7 @@
     <nuclide name="Zr92" wo="0.14759527104" />
     <nuclide name="Zr94" wo="0.15280552077" />
     <nuclide name="Zr96" wo="0.02511169542" />
-    <sab name="c_H_in_H2O" />
+    <sab fraction="1.0" name="c_H_in_H2O" />
   </material>
   <material id="12" name="Bottom of fuel assemblies">
     <density units="g/cm3" value="1.762" />
@@ -292,7 +292,7 @@
     <nuclide name="Zr92" wo="0.1274914944" />
     <nuclide name="Zr94" wo="0.1319920622" />
     <nuclide name="Zr96" wo="0.0216912612" />
-    <sab name="c_H_in_H2O" />
+    <sab fraction="1.0" name="c_H_in_H2O" />
   </material>
 </materials>
 <?xml version='1.0' encoding='utf-8'?>

--- a/tests/test_mgxs_library_no_nuclides/inputs_true.dat
+++ b/tests/test_mgxs_library_no_nuclides/inputs_true.dat
@@ -33,7 +33,7 @@
     <nuclide ao="0.024672" name="O16" />
     <nuclide ao="8.0042e-06" name="B10" />
     <nuclide ao="3.2218e-05" name="B11" />
-    <sab name="c_H_in_H2O" />
+    <sab fraction="1.0" name="c_H_in_H2O" />
   </material>
 </materials>
 <?xml version='1.0' encoding='utf-8'?>

--- a/tests/test_mgxs_library_nuclides/inputs_true.dat
+++ b/tests/test_mgxs_library_nuclides/inputs_true.dat
@@ -33,7 +33,7 @@
     <nuclide ao="0.024672" name="O16" />
     <nuclide ao="8.0042e-06" name="B10" />
     <nuclide ao="3.2218e-05" name="B11" />
-    <sab name="c_H_in_H2O" />
+    <sab fraction="1.0" name="c_H_in_H2O" />
   </material>
 </materials>
 <?xml version='1.0' encoding='utf-8'?>

--- a/tests/test_multipole/inputs_true.dat
+++ b/tests/test_multipole/inputs_true.dat
@@ -25,7 +25,7 @@
     <density units="g/cc" value="1.0" />
     <nuclide ao="2.0" name="H1" />
     <nuclide ao="1.0" name="O16" />
-    <sab name="c_H_in_H2O" />
+    <sab fraction="1.0" name="c_H_in_H2O" />
   </material>
   <material id="2">
     <density units="g/cc" value="4.5" />

--- a/tests/test_periodic/inputs_true.dat
+++ b/tests/test_periodic/inputs_true.dat
@@ -16,7 +16,7 @@
     <density units="g/cc" value="1.0" />
     <nuclide ao="2.0" name="H1" />
     <nuclide ao="1.0" name="O16" />
-    <sab name="c_H_in_H2O" />
+    <sab fraction="1.0" name="c_H_in_H2O" />
   </material>
   <material id="2">
     <density units="g/cc" value="4.5" />

--- a/tests/test_tallies/inputs_true.dat
+++ b/tests/test_tallies/inputs_true.dat
@@ -170,7 +170,7 @@
     <nuclide ao="1.0" name="O16" />
     <nuclide ao="0.000649" name="B10" />
     <nuclide ao="0.002689" name="B11" />
-    <sab name="c_H_in_H2O" />
+    <sab fraction="1.0" name="c_H_in_H2O" />
   </material>
   <material id="4" name="Hot borated water">
     <density units="atom/b-cm" value="0.06614" />
@@ -178,7 +178,7 @@
     <nuclide ao="1.0" name="O16" />
     <nuclide ao="0.000649" name="B10" />
     <nuclide ao="0.002689" name="B11" />
-    <sab name="c_H_in_H2O" />
+    <sab fraction="1.0" name="c_H_in_H2O" />
   </material>
   <material id="5" name="Reactor pressure vessel steel">
     <density units="g/cm3" value="7.9" />
@@ -206,7 +206,7 @@
     <nuclide name="Ni58" wo="0.055298376566" />
     <nuclide name="Mn55" wo="0.018287" />
     <nuclide name="Cr52" wo="0.145407678031" />
-    <sab name="c_H_in_H2O" />
+    <sab fraction="1.0" name="c_H_in_H2O" />
   </material>
   <material id="7" name="Upper radial reflector / Top plate region">
     <density units="g/cm3" value="4.28" />
@@ -221,7 +221,7 @@
     <nuclide name="Ni58" wo="0.055815129186" />
     <nuclide name="Mn55" wo="0.0184579" />
     <nuclide name="Cr52" wo="0.146766614995" />
-    <sab name="c_H_in_H2O" />
+    <sab fraction="1.0" name="c_H_in_H2O" />
   </material>
   <material id="8" name="Bottom plate region">
     <density units="g/cm3" value="7.184" />
@@ -236,7 +236,7 @@
     <nuclide name="Ni58" wo="0.059855207342" />
     <nuclide name="Mn55" wo="0.019794" />
     <nuclide name="Cr52" wo="0.157390026871" />
-    <sab name="c_H_in_H2O" />
+    <sab fraction="1.0" name="c_H_in_H2O" />
   </material>
   <material id="9" name="Bottom nozzle region">
     <density units="g/cm3" value="2.53" />
@@ -251,7 +251,7 @@
     <nuclide name="Ni58" wo="0.047211231662" />
     <nuclide name="Mn55" wo="0.0156126" />
     <nuclide name="Cr52" wo="0.124142524198" />
-    <sab name="c_H_in_H2O" />
+    <sab fraction="1.0" name="c_H_in_H2O" />
   </material>
   <material id="10" name="Top nozzle region">
     <density units="g/cm3" value="1.746" />
@@ -266,7 +266,7 @@
     <nuclide name="Ni58" wo="0.04104621835" />
     <nuclide name="Mn55" wo="0.0135739" />
     <nuclide name="Cr52" wo="0.107931450781" />
-    <sab name="c_H_in_H2O" />
+    <sab fraction="1.0" name="c_H_in_H2O" />
   </material>
   <material id="11" name="Top of fuel assemblies">
     <density units="g/cm3" value="3.044" />
@@ -279,7 +279,7 @@
     <nuclide name="Zr92" wo="0.14759527104" />
     <nuclide name="Zr94" wo="0.15280552077" />
     <nuclide name="Zr96" wo="0.02511169542" />
-    <sab name="c_H_in_H2O" />
+    <sab fraction="1.0" name="c_H_in_H2O" />
   </material>
   <material id="12" name="Bottom of fuel assemblies">
     <density units="g/cm3" value="1.762" />
@@ -292,7 +292,7 @@
     <nuclide name="Zr92" wo="0.1274914944" />
     <nuclide name="Zr94" wo="0.1319920622" />
     <nuclide name="Zr96" wo="0.0216912612" />
-    <sab name="c_H_in_H2O" />
+    <sab fraction="1.0" name="c_H_in_H2O" />
   </material>
 </materials>
 <?xml version='1.0' encoding='utf-8'?>

--- a/tests/test_tally_aggregation/inputs_true.dat
+++ b/tests/test_tally_aggregation/inputs_true.dat
@@ -170,7 +170,7 @@
     <nuclide ao="1.0" name="O16" />
     <nuclide ao="0.000649" name="B10" />
     <nuclide ao="0.002689" name="B11" />
-    <sab name="c_H_in_H2O" />
+    <sab fraction="1.0" name="c_H_in_H2O" />
   </material>
   <material id="4" name="Hot borated water">
     <density units="atom/b-cm" value="0.06614" />
@@ -178,7 +178,7 @@
     <nuclide ao="1.0" name="O16" />
     <nuclide ao="0.000649" name="B10" />
     <nuclide ao="0.002689" name="B11" />
-    <sab name="c_H_in_H2O" />
+    <sab fraction="1.0" name="c_H_in_H2O" />
   </material>
   <material id="5" name="Reactor pressure vessel steel">
     <density units="g/cm3" value="7.9" />
@@ -206,7 +206,7 @@
     <nuclide name="Ni58" wo="0.055298376566" />
     <nuclide name="Mn55" wo="0.018287" />
     <nuclide name="Cr52" wo="0.145407678031" />
-    <sab name="c_H_in_H2O" />
+    <sab fraction="1.0" name="c_H_in_H2O" />
   </material>
   <material id="7" name="Upper radial reflector / Top plate region">
     <density units="g/cm3" value="4.28" />
@@ -221,7 +221,7 @@
     <nuclide name="Ni58" wo="0.055815129186" />
     <nuclide name="Mn55" wo="0.0184579" />
     <nuclide name="Cr52" wo="0.146766614995" />
-    <sab name="c_H_in_H2O" />
+    <sab fraction="1.0" name="c_H_in_H2O" />
   </material>
   <material id="8" name="Bottom plate region">
     <density units="g/cm3" value="7.184" />
@@ -236,7 +236,7 @@
     <nuclide name="Ni58" wo="0.059855207342" />
     <nuclide name="Mn55" wo="0.019794" />
     <nuclide name="Cr52" wo="0.157390026871" />
-    <sab name="c_H_in_H2O" />
+    <sab fraction="1.0" name="c_H_in_H2O" />
   </material>
   <material id="9" name="Bottom nozzle region">
     <density units="g/cm3" value="2.53" />
@@ -251,7 +251,7 @@
     <nuclide name="Ni58" wo="0.047211231662" />
     <nuclide name="Mn55" wo="0.0156126" />
     <nuclide name="Cr52" wo="0.124142524198" />
-    <sab name="c_H_in_H2O" />
+    <sab fraction="1.0" name="c_H_in_H2O" />
   </material>
   <material id="10" name="Top nozzle region">
     <density units="g/cm3" value="1.746" />
@@ -266,7 +266,7 @@
     <nuclide name="Ni58" wo="0.04104621835" />
     <nuclide name="Mn55" wo="0.0135739" />
     <nuclide name="Cr52" wo="0.107931450781" />
-    <sab name="c_H_in_H2O" />
+    <sab fraction="1.0" name="c_H_in_H2O" />
   </material>
   <material id="11" name="Top of fuel assemblies">
     <density units="g/cm3" value="3.044" />
@@ -279,7 +279,7 @@
     <nuclide name="Zr92" wo="0.14759527104" />
     <nuclide name="Zr94" wo="0.15280552077" />
     <nuclide name="Zr96" wo="0.02511169542" />
-    <sab name="c_H_in_H2O" />
+    <sab fraction="1.0" name="c_H_in_H2O" />
   </material>
   <material id="12" name="Bottom of fuel assemblies">
     <density units="g/cm3" value="1.762" />
@@ -292,7 +292,7 @@
     <nuclide name="Zr92" wo="0.1274914944" />
     <nuclide name="Zr94" wo="0.1319920622" />
     <nuclide name="Zr96" wo="0.0216912612" />
-    <sab name="c_H_in_H2O" />
+    <sab fraction="1.0" name="c_H_in_H2O" />
   </material>
 </materials>
 <?xml version='1.0' encoding='utf-8'?>

--- a/tests/test_tally_arithmetic/inputs_true.dat
+++ b/tests/test_tally_arithmetic/inputs_true.dat
@@ -170,7 +170,7 @@
     <nuclide ao="1.0" name="O16" />
     <nuclide ao="0.000649" name="B10" />
     <nuclide ao="0.002689" name="B11" />
-    <sab name="c_H_in_H2O" />
+    <sab fraction="1.0" name="c_H_in_H2O" />
   </material>
   <material id="4" name="Hot borated water">
     <density units="atom/b-cm" value="0.06614" />
@@ -178,7 +178,7 @@
     <nuclide ao="1.0" name="O16" />
     <nuclide ao="0.000649" name="B10" />
     <nuclide ao="0.002689" name="B11" />
-    <sab name="c_H_in_H2O" />
+    <sab fraction="1.0" name="c_H_in_H2O" />
   </material>
   <material id="5" name="Reactor pressure vessel steel">
     <density units="g/cm3" value="7.9" />
@@ -206,7 +206,7 @@
     <nuclide name="Ni58" wo="0.055298376566" />
     <nuclide name="Mn55" wo="0.018287" />
     <nuclide name="Cr52" wo="0.145407678031" />
-    <sab name="c_H_in_H2O" />
+    <sab fraction="1.0" name="c_H_in_H2O" />
   </material>
   <material id="7" name="Upper radial reflector / Top plate region">
     <density units="g/cm3" value="4.28" />
@@ -221,7 +221,7 @@
     <nuclide name="Ni58" wo="0.055815129186" />
     <nuclide name="Mn55" wo="0.0184579" />
     <nuclide name="Cr52" wo="0.146766614995" />
-    <sab name="c_H_in_H2O" />
+    <sab fraction="1.0" name="c_H_in_H2O" />
   </material>
   <material id="8" name="Bottom plate region">
     <density units="g/cm3" value="7.184" />
@@ -236,7 +236,7 @@
     <nuclide name="Ni58" wo="0.059855207342" />
     <nuclide name="Mn55" wo="0.019794" />
     <nuclide name="Cr52" wo="0.157390026871" />
-    <sab name="c_H_in_H2O" />
+    <sab fraction="1.0" name="c_H_in_H2O" />
   </material>
   <material id="9" name="Bottom nozzle region">
     <density units="g/cm3" value="2.53" />
@@ -251,7 +251,7 @@
     <nuclide name="Ni58" wo="0.047211231662" />
     <nuclide name="Mn55" wo="0.0156126" />
     <nuclide name="Cr52" wo="0.124142524198" />
-    <sab name="c_H_in_H2O" />
+    <sab fraction="1.0" name="c_H_in_H2O" />
   </material>
   <material id="10" name="Top nozzle region">
     <density units="g/cm3" value="1.746" />
@@ -266,7 +266,7 @@
     <nuclide name="Ni58" wo="0.04104621835" />
     <nuclide name="Mn55" wo="0.0135739" />
     <nuclide name="Cr52" wo="0.107931450781" />
-    <sab name="c_H_in_H2O" />
+    <sab fraction="1.0" name="c_H_in_H2O" />
   </material>
   <material id="11" name="Top of fuel assemblies">
     <density units="g/cm3" value="3.044" />
@@ -279,7 +279,7 @@
     <nuclide name="Zr92" wo="0.14759527104" />
     <nuclide name="Zr94" wo="0.15280552077" />
     <nuclide name="Zr96" wo="0.02511169542" />
-    <sab name="c_H_in_H2O" />
+    <sab fraction="1.0" name="c_H_in_H2O" />
   </material>
   <material id="12" name="Bottom of fuel assemblies">
     <density units="g/cm3" value="1.762" />
@@ -292,7 +292,7 @@
     <nuclide name="Zr92" wo="0.1274914944" />
     <nuclide name="Zr94" wo="0.1319920622" />
     <nuclide name="Zr96" wo="0.0216912612" />
-    <sab name="c_H_in_H2O" />
+    <sab fraction="1.0" name="c_H_in_H2O" />
   </material>
 </materials>
 <?xml version='1.0' encoding='utf-8'?>

--- a/tests/test_tally_slice_merge/inputs_true.dat
+++ b/tests/test_tally_slice_merge/inputs_true.dat
@@ -170,7 +170,7 @@
     <nuclide ao="1.0" name="O16" />
     <nuclide ao="0.000649" name="B10" />
     <nuclide ao="0.002689" name="B11" />
-    <sab name="c_H_in_H2O" />
+    <sab fraction="1.0" name="c_H_in_H2O" />
   </material>
   <material id="4" name="Hot borated water">
     <density units="atom/b-cm" value="0.06614" />
@@ -178,7 +178,7 @@
     <nuclide ao="1.0" name="O16" />
     <nuclide ao="0.000649" name="B10" />
     <nuclide ao="0.002689" name="B11" />
-    <sab name="c_H_in_H2O" />
+    <sab fraction="1.0" name="c_H_in_H2O" />
   </material>
   <material id="5" name="Reactor pressure vessel steel">
     <density units="g/cm3" value="7.9" />
@@ -206,7 +206,7 @@
     <nuclide name="Ni58" wo="0.055298376566" />
     <nuclide name="Mn55" wo="0.018287" />
     <nuclide name="Cr52" wo="0.145407678031" />
-    <sab name="c_H_in_H2O" />
+    <sab fraction="1.0" name="c_H_in_H2O" />
   </material>
   <material id="7" name="Upper radial reflector / Top plate region">
     <density units="g/cm3" value="4.28" />
@@ -221,7 +221,7 @@
     <nuclide name="Ni58" wo="0.055815129186" />
     <nuclide name="Mn55" wo="0.0184579" />
     <nuclide name="Cr52" wo="0.146766614995" />
-    <sab name="c_H_in_H2O" />
+    <sab fraction="1.0" name="c_H_in_H2O" />
   </material>
   <material id="8" name="Bottom plate region">
     <density units="g/cm3" value="7.184" />
@@ -236,7 +236,7 @@
     <nuclide name="Ni58" wo="0.059855207342" />
     <nuclide name="Mn55" wo="0.019794" />
     <nuclide name="Cr52" wo="0.157390026871" />
-    <sab name="c_H_in_H2O" />
+    <sab fraction="1.0" name="c_H_in_H2O" />
   </material>
   <material id="9" name="Bottom nozzle region">
     <density units="g/cm3" value="2.53" />
@@ -251,7 +251,7 @@
     <nuclide name="Ni58" wo="0.047211231662" />
     <nuclide name="Mn55" wo="0.0156126" />
     <nuclide name="Cr52" wo="0.124142524198" />
-    <sab name="c_H_in_H2O" />
+    <sab fraction="1.0" name="c_H_in_H2O" />
   </material>
   <material id="10" name="Top nozzle region">
     <density units="g/cm3" value="1.746" />
@@ -266,7 +266,7 @@
     <nuclide name="Ni58" wo="0.04104621835" />
     <nuclide name="Mn55" wo="0.0135739" />
     <nuclide name="Cr52" wo="0.107931450781" />
-    <sab name="c_H_in_H2O" />
+    <sab fraction="1.0" name="c_H_in_H2O" />
   </material>
   <material id="11" name="Top of fuel assemblies">
     <density units="g/cm3" value="3.044" />
@@ -279,7 +279,7 @@
     <nuclide name="Zr92" wo="0.14759527104" />
     <nuclide name="Zr94" wo="0.15280552077" />
     <nuclide name="Zr96" wo="0.02511169542" />
-    <sab name="c_H_in_H2O" />
+    <sab fraction="1.0" name="c_H_in_H2O" />
   </material>
   <material id="12" name="Bottom of fuel assemblies">
     <density units="g/cm3" value="1.762" />
@@ -292,7 +292,7 @@
     <nuclide name="Zr92" wo="0.1274914944" />
     <nuclide name="Zr94" wo="0.1319920622" />
     <nuclide name="Zr96" wo="0.0216912612" />
-    <sab name="c_H_in_H2O" />
+    <sab fraction="1.0" name="c_H_in_H2O" />
   </material>
 </materials>
 <?xml version='1.0' encoding='utf-8'?>

--- a/tests/test_triso/inputs_true.dat
+++ b/tests/test_triso/inputs_true.dat
@@ -403,12 +403,12 @@
   <material id="14">
     <density units="g/cm3" value="1.0" />
     <nuclide ao="1.0" name="C0" />
-    <sab name="c_Graphite" />
+    <sab fraction="1.0" name="c_Graphite" />
   </material>
   <material id="15">
     <density units="g/cm3" value="1.9" />
     <nuclide ao="1.0" name="C0" />
-    <sab name="c_Graphite" />
+    <sab fraction="1.0" name="c_Graphite" />
   </material>
   <material id="16">
     <density units="g/cm3" value="3.2" />
@@ -420,12 +420,12 @@
   <material id="17">
     <density units="g/cm3" value="1.87" />
     <nuclide ao="1.0" name="C0" />
-    <sab name="c_Graphite" />
+    <sab fraction="1.0" name="c_Graphite" />
   </material>
   <material id="18">
     <density units="g/cm3" value="1.1995" />
     <nuclide ao="1.0" name="C0" />
-    <sab name="c_Graphite" />
+    <sab fraction="1.0" name="c_Graphite" />
   </material>
 </materials>
 <?xml version='1.0' encoding='utf-8'?>

--- a/tests/test_volume_calc/inputs_true.dat
+++ b/tests/test_volume_calc/inputs_true.dat
@@ -16,7 +16,7 @@
     <nuclide ao="2.0" name="H1" />
     <nuclide ao="1.0" name="O16" />
     <nuclide ao="0.0001" name="B10" />
-    <sab name="c_H_in_H2O" />
+    <sab fraction="1.0" name="c_H_in_H2O" />
   </material>
   <material id="2">
     <density units="g/cc" value="4.5" />


### PR DESCRIPTION
The tests contain a file `inputs_true.dat` with the expected XML input for OpenMC.

With the changes in the `partial_sab` branch, the reference inputs needed to be updated to include the `fraction=` attribute. This PR should fix that.